### PR TITLE
feat(async-retry): bring up

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,12 @@
       "require": "./dist/append-set-elements-to-array/index.js",
       "default": "./dist/append-set-elements-to-array/index.js"
     },
+    "./async-retry": {
+      "types": "./dist/async-retry/index.d.ts",
+      "import": "./dist/async-retry/index.mjs",
+      "require": "./dist/async-retry/index.js",
+      "default": "./dist/async-retry/index.js"
+    },
     "./async-write-to-stream": {
       "types": "./dist/async-write-to-stream/index.d.ts",
       "import": "./dist/async-write-to-stream/index.mjs",

--- a/src/async-retry/index.test.ts
+++ b/src/async-retry/index.test.ts
@@ -1,0 +1,1102 @@
+/* eslint-disable @typescript-eslint/no-empty-function -- unit test */
+/* eslint-disable @typescript-eslint/require-await -- unit test */
+import { describe, it } from 'mocha';
+import { expect } from 'expect';
+import { wait } from '../wait';
+import { asyncRetry, makeRetriable, AsyncRetryAbortError } from '.';
+import { spy, stub } from 'sinon';
+
+// Prevent unit test from stalling
+const sharedOpt = {
+  factor: 1,
+  minTimeout: 5,
+  maxTimeout: 80
+};
+
+describe('async-retry', () => {
+  it('return value', async () => {
+    const val = await asyncRetry(async (bail, num) => {
+      if (num < 2) {
+        throw new Error('woot');
+      }
+
+      await wait(50);
+      return `woot ${num}`;
+    }, sharedOpt);
+
+    expect(val).toEqual('woot 2');
+  });
+
+  it('return value no await', async () => {
+    const val = await asyncRetry(async (bail, num) => num);
+    expect(val).toEqual(1);
+  });
+
+  it('chained promise', async () => {
+    const res = await asyncRetry((bail, num) => {
+      if (num < 2) {
+        throw new Error('retry');
+      }
+
+      return new Response('ok', { status: 200 });
+    }, sharedOpt);
+
+    expect(res.status).toEqual(200);
+  });
+
+  it('bail', async () => {
+    await expect(asyncRetry(
+
+      async (bail, num) => {
+        if (num === 2) {
+          bail(new Error('Wont retry'));
+        }
+
+        throw new Error(`Test ${num}`);
+      },
+      { ...sharedOpt, retries: 3 }
+    )).rejects.toThrow('Wont retry');
+  });
+
+  it('bail + return', async () => {
+    await expect(Promise.resolve(
+      asyncRetry(async bail => {
+        await wait(20);
+        await wait(20);
+        bail(new Error('woot'));
+      }, sharedOpt)
+    )).rejects.toThrow('woot');
+  });
+
+  it('bail error', async () => {
+    let retries = 0;
+
+    await expect(asyncRetry(
+      async () => {
+        retries += 1;
+        await wait(100);
+        const err = new Error('Wont retry');
+        Object.assign(err, { bail: true });
+        throw err;
+      },
+      { ...sharedOpt, retries: 3 }
+    )).rejects.toThrow('Wont retry');
+
+    expect(retries).toEqual(1);
+  });
+
+  it('with non-async functions', async () => {
+    await expect(asyncRetry(
+      (bail, num) => {
+        throw new Error(`Test ${num}`);
+      },
+      { ...sharedOpt, retries: 2 }
+    )).rejects.toThrow('Test 3');
+  });
+
+  it('return non-async', async () => {
+    const val = await asyncRetry(() => 5);
+    expect(val).toEqual(5);
+  });
+
+  it('with number of retries', async () => {
+    let retries = 0;
+
+    await expect(asyncRetry(() => { throw new Error('test'); }, {
+      ...sharedOpt,
+      retries: 2,
+      onRetry(err, i) {
+        retries = i;
+      }
+    })).rejects.toBeTruthy();
+
+    expect(retries).toEqual(2);
+  });
+
+  const fixture = Symbol('fixture');
+  const fixtureError = new Error('fixture');
+
+  it('retries', async () => {
+    let index = 0;
+
+    const returnValue = await asyncRetry(async (bail, attemptNumber) => {
+      await wait(5);
+      index++;
+
+      return attemptNumber === 3 ? fixture : Promise.reject(fixtureError);
+    }, sharedOpt);
+
+    expect(returnValue).toEqual(fixture);
+    expect(index).toEqual(3);
+  });
+
+  it('retries forever when specified', async () => {
+    let attempts = 0;
+    const maxAttempts = 15; // Limit for test purposes
+
+    await expect(asyncRetry(
+      async () => {
+        attempts++;
+        if (attempts === maxAttempts) {
+          throw new AsyncRetryAbortError('stop');
+        }
+
+        throw new Error('test');
+      },
+      {
+        factor: 1,
+        retries: Number.POSITIVE_INFINITY,
+        minTimeout: 0 // Speed up test
+      }
+    )).rejects.toBeTruthy();
+
+    expect(attempts).toEqual(maxAttempts);
+  });
+
+  // Error Handling Tests
+  it('throws original error', async () => {
+    await expect(asyncRetry(() => {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error -- unit test
+      throw 'foo';
+    }, sharedOpt)).rejects.toBe('foo');
+  });
+
+  it('no retry on TypeError', async () => {
+    const typeErrorFixture = new TypeError('type-error-fixture');
+    let index = 0;
+
+    await expect(asyncRetry(async (bail, attemptNumber) => {
+      await wait(20);
+      index++;
+      return attemptNumber === 3 ? fixture : Promise.reject(typeErrorFixture);
+    }, sharedOpt)).rejects.toThrow(typeErrorFixture);
+
+    expect(index).toEqual(1);
+  });
+
+  it('shouldRetry is not called for non-network TypeError', async () => {
+    const typeErrorFixture = new TypeError('type-error-fixture');
+    let shouldRetryCalled = 0;
+
+    await expect(asyncRetry(async () => {
+      throw typeErrorFixture;
+    }, {
+      ...sharedOpt,
+      shouldRetry() {
+        shouldRetryCalled++;
+        return true;
+      }
+    })).rejects.toThrow(typeErrorFixture);
+
+    expect(shouldRetryCalled).toEqual(0);
+  });
+
+  it('retry on TypeError - failed to fetch', async () => {
+    const typeErrorFixture = new TypeError('Failed to fetch');
+    let index = 0;
+
+    const returnValue = await asyncRetry(async (bail, attemptNumber) => {
+      await wait(20);
+      index++;
+      return attemptNumber === 3 ? fixture : Promise.reject(typeErrorFixture);
+    }, sharedOpt);
+
+    expect(returnValue).toEqual(fixture);
+    expect(index).toEqual(3);
+  });
+
+  it('errors are preserved when maxRetryTime exceeded', async () => {
+    const originalError = new Error('original error');
+    const maxRetryTime = 50;
+    let startTime;
+
+    await expect(asyncRetry(
+      async () => {
+        startTime ||= Date.now();
+
+        await wait(maxRetryTime + 25); // Ensure we exceed maxRetryTime
+        throw originalError;
+      },
+      {
+        maxRetryTime,
+        minTimeout: 0
+      }
+    )).rejects.toBe(originalError);
+  });
+
+  it('AbortError - string', () => {
+    const error = new AsyncRetryAbortError('fixture').cause;
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).constructor.name).toEqual('Error');
+    expect((error as Error).message).toEqual('fixture');
+  });
+
+  it('AbortError - error', () => {
+    const error = new AsyncRetryAbortError(new Error('fixture')).cause;
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).constructor.name).toEqual('Error');
+    expect((error as Error).message).toEqual('fixture');
+  });
+
+  it('aborts', async () => {
+    let index = 0;
+
+    await expect(asyncRetry(async (bail, attemptNumber) => {
+      await wait(20);
+      index++;
+      return attemptNumber === 3 ? Promise.reject(new AsyncRetryAbortError(fixtureError)) : Promise.reject(fixtureError);
+    }, sharedOpt)).rejects.toBe(fixtureError);
+
+    expect(index).toEqual(3);
+  });
+
+  it('operation stops immediately on AbortError', async () => {
+    let attempts = 0;
+
+    await expect(asyncRetry(
+
+      async () => {
+        attempts++;
+        if (attempts === 2) {
+          throw new AsyncRetryAbortError('stop');
+        }
+
+        throw new Error('test');
+      },
+      {
+        retries: 10,
+        minTimeout: 0
+      }
+    )).rejects.toBeTruthy();
+
+    expect(attempts).toEqual(2); // Should stop after AbortError
+  });
+
+  it('shouldRetry is not called for AbortError', async () => {
+    let shouldRetryCalled = 0;
+
+    await expect(asyncRetry(async () => {
+      throw new AsyncRetryAbortError('stop');
+    }, {
+      shouldRetry() {
+        shouldRetryCalled++;
+        return true;
+      }
+    })).rejects.toThrow('stop');
+
+    expect(shouldRetryCalled).toEqual(0);
+  });
+
+  it('aborts with an AbortSignal', async () => {
+    let index = 0;
+    const controller = new AbortController();
+
+    await expect(asyncRetry(async (_, attemptNumber) => {
+      await wait(20);
+      index++;
+      if (attemptNumber === 3) {
+        controller.abort();
+      }
+
+      throw fixtureError;
+    }, {
+      ...sharedOpt,
+      signal: controller.signal
+    })).rejects.toBeTruthy();
+
+    expect(index).toEqual(3);
+  });
+
+  it('preserves the abort reason', async () => {
+    let index = 0;
+    const controller = new AbortController();
+
+    await expect(asyncRetry(async (bail, attemptNumber) => {
+      await wait(20);
+      index++;
+      if (attemptNumber === 3) {
+        controller.abort(fixtureError);
+        return;
+      }
+
+      throw fixtureError;
+    }, {
+      ...sharedOpt,
+      signal: controller.signal
+    })).rejects.toBe(fixtureError);
+
+    expect(index).toEqual(3);
+  });
+
+  it('shouldRetry controls retry behavior', async () => {
+    const shouldRetryError = new Error('should-retry');
+    const customError = new Error('custom-error');
+    let index = 0;
+
+    await expect(asyncRetry(async () => {
+      await wait(20);
+      index++;
+      const error = index < 3 ? shouldRetryError : customError;
+      throw error;
+    }, {
+      ...sharedOpt,
+      shouldRetry({ error }) {
+        return (error as Error).message === shouldRetryError.message;
+      },
+      retries: 10
+    })).rejects.toThrow(customError);
+
+    expect(index).toEqual(3);
+  });
+
+  it('onFailedAttempt then shouldRetry order', async () => {
+    const order: string[] = [];
+
+    await expect(asyncRetry(async () => {
+      throw new Error('order');
+    }, {
+      onFailedAttempt() {
+        order.push('onFailedAttempt');
+      },
+      shouldRetry() {
+        order.push('shouldRetry');
+        return false;
+      }
+    })).rejects.toBeTruthy();
+
+    expect(order).toEqual(['onFailedAttempt', 'shouldRetry']);
+  });
+
+  it('handles async shouldRetry with maxRetryTime', async () => {
+    let attempts = 0;
+    const start = Date.now();
+    const maxRetryTime = 50;
+
+    await expect(asyncRetry(
+      async () => {
+        attempts++;
+        throw new Error('test');
+      },
+      {
+        ...sharedOpt,
+        retries: 10,
+        maxRetryTime,
+        async shouldRetry() {
+          await wait(20);
+          return true;
+        }
+      }
+    )).rejects.toBeTruthy();
+
+    expect(Date.now() - start).toBeLessThanOrEqual(maxRetryTime + 25);
+    expect(attempts).toBeLessThan(10);
+  });
+
+  it('onFailedAttempt provides correct error details', async () => {
+    const retries = 5;
+    let index = 0;
+    let attemptNumber = 0;
+
+    await asyncRetry(
+      async (bail, attemptNumber) => {
+        await wait(20);
+        index++;
+        return attemptNumber === 3 ? fixture : Promise.reject(fixtureError);
+      },
+      {
+        ...sharedOpt,
+        onFailedAttempt({ error, attemptNumber: attempt, retriesLeft }) {
+          expect(error).toEqual(fixtureError);
+          expect(attempt).toEqual(++attemptNumber);
+          expect(retriesLeft).toEqual(retries - (index - 1));
+        },
+        retries
+      }
+    );
+
+    expect(index).toEqual(3);
+    expect(attemptNumber).toEqual(2);
+  });
+
+  it('onFailedAttempt is called even when shouldRetry returns false', async () => {
+    const error = new Error('fail');
+    let onFailedAttemptCount = 0;
+    let attempts = 0;
+
+    await expect(asyncRetry(async () => {
+      attempts++;
+      throw error;
+    }, {
+      onFailedAttempt() {
+        onFailedAttemptCount++;
+      },
+      shouldRetry: () => false,
+      retries: 5
+    })).rejects.toBe(error);
+
+    expect(attempts).toEqual(1);
+    expect(onFailedAttemptCount).toEqual(1);
+  });
+
+  it('onFailedAttempt can return a promise to add a delay', async () => {
+    const waitFor = 100;
+    const start = Date.now();
+    let isCalled: boolean;
+
+    await asyncRetry(
+      async () => {
+        if (isCalled) {
+          return fixture;
+        }
+
+        isCalled = true;
+        throw fixtureError;
+      },
+      {
+        ...sharedOpt,
+        async onFailedAttempt() {
+          await wait(waitFor);
+        }
+      }
+    );
+
+    expect(Date.now()).toBeGreaterThan(start + waitFor);
+  });
+
+  it('onFailedAttempt can throw to abort retries', async () => {
+    const error = new Error('thrown from onFailedAttempt');
+
+    await expect(asyncRetry(async () => {
+      throw fixtureError;
+    }, {
+      onFailedAttempt() {
+        throw error;
+      }
+    })).rejects.toBe(error);
+  });
+
+  it('retry context object is immutable', async () => {
+    await expect(asyncRetry(async () => {
+      throw new Error('fail');
+    }, {
+      ...sharedOpt,
+      onFailedAttempt(context) {
+        // Attempt to mutate frozen object in strict mode should throw
+        Object.defineProperty(context, 'foo', { value: 'bar' });
+      }
+    })).rejects.toBeTruthy();
+  });
+
+  it('onFailedAttempt can be undefined', async () => {
+    const error = new Error('thrown from onFailedAttempt');
+
+    await expect(asyncRetry(() => {
+      throw error;
+    }, {
+      ...sharedOpt,
+      onFailedAttempt: undefined,
+      retries: 1
+    })).rejects.toBe(error);
+  });
+
+  it('shouldRetry can be undefined', async () => {
+    const error = new Error('thrown from onFailedAttempt');
+
+    await expect(asyncRetry(() => {
+      throw error;
+    }, {
+      ...sharedOpt,
+      shouldRetry: undefined,
+      retries: 1
+    })).rejects.toBe(error);
+  });
+
+  it('factor affects exponential backoff', async () => {
+    const sTO = spy(globalThis, 'setTimeout');
+
+    try {
+      await expect(asyncRetry(
+        async () => {
+          throw new Error('test');
+        },
+        {
+          retries: 3,
+          factor: 2,
+          minTimeout: 10,
+          maxTimeout: Number.POSITIVE_INFINITY,
+          randomize: false
+        }
+      )).rejects.toBeTruthy();
+
+      expect(sTO.getCalls().map(call => call.args[1])).toEqual([10, 20, 40]);
+    } finally {
+      sTO.restore();
+    }
+  });
+
+  it('timeouts are incremental with factor', async () => {
+    const sTO = spy(globalThis, 'setTimeout');
+
+    try {
+      await expect(asyncRetry(
+        async () => {
+          throw new Error('test');
+        },
+        {
+          retries: 3,
+          factor: 0.5,
+          minTimeout: 40,
+          maxTimeout: Number.POSITIVE_INFINITY,
+          randomize: false
+        }
+      )).rejects.toBeTruthy();
+
+      // With factor 0.5 and minTimeout 100, expected delays: 100, 50, 25 (before rounding)
+      expect(sTO.getCalls().map(call => call.args[1])).toEqual([40, 20, 10]);
+    } finally {
+      sTO.restore();
+    }
+  });
+
+  it('minTimeout is respected even with small factor', async () => {
+    const sTO = spy(globalThis, 'setTimeout');
+
+    try {
+      await expect(asyncRetry(
+        async () => {
+          throw new Error('test');
+        },
+        {
+          retries: 2,
+          factor: 0.1,
+          minTimeout: 10,
+          maxTimeout: Number.POSITIVE_INFINITY,
+          randomize: false
+        }
+      )).rejects.toBeTruthy();
+
+      // First delay is at least minTimeout. Second is minTimeout * 0.1 = 10
+      expect(sTO.getCalls().map(call => call.args[1])).toEqual([10, 1]);
+    } finally {
+      sTO.restore();
+    }
+  });
+
+  it('maxTimeout caps retry delays', async () => {
+    const sTO = spy(globalThis, 'setTimeout');
+
+    try {
+      await expect(asyncRetry(
+        async () => {
+          throw new Error('test');
+        },
+        {
+          retries: 3,
+          minTimeout: 10,
+          factor: 3,
+          maxTimeout: 25,
+          randomize: false
+        }
+      )).rejects.toBeTruthy();
+
+      expect(sTO.callCount).toEqual(3);
+      expect(sTO.getCalls().map(call => call.args[1])).toEqual([10, 25, 25]);
+    } finally {
+      sTO.restore();
+    }
+  });
+
+  it('maxTimeout lower than minTimeout caps delay', async () => {
+    const start = Date.now();
+    await expect(asyncRetry(async () => {
+      throw new Error('fail');
+    }, {
+      retries: 1,
+      minTimeout: 200,
+      maxTimeout: 50,
+      factor: 1
+    })).rejects.toBeTruthy();
+
+    const elapsed = Date.now() - start;
+    // Should be significantly less than minTimeout due to capping
+    expect(elapsed).toBeLessThan(200);
+  });
+
+  it('randomize affects retry delays', async () => {
+    let calls = 0;
+    const sequence = [0, 1, 0.5]; // → factors 1x, 2x, 1.5x
+
+    const sTO = spy(globalThis, 'setTimeout');
+
+    const randomStub = stub(Math, 'random').callsFake(() => sequence[calls++] ?? 0);
+
+    try {
+      await expect(asyncRetry(
+        async () => {
+          throw new Error('test');
+        },
+        {
+          retries: 3,
+          minTimeout: 8,
+          factor: 1,
+          randomize: true
+        }
+      )).rejects.toBeTruthy();
+
+      expect(sTO.getCalls().map(call => call.args[1])).toEqual([8, 16, 12]);
+    } finally {
+      sTO.restore();
+      randomStub.restore();
+    }
+  });
+
+  it('maxRetryTime limits total retry duration', async () => {
+    const start = Date.now();
+    const maxRetryTime = 20;
+
+    await expect(asyncRetry(
+      async () => {
+        await wait(50);
+        throw new Error('test');
+      },
+      {
+        retries: 10,
+        minTimeout: 50,
+        maxRetryTime
+      }
+    )).rejects.toBeTruthy();
+
+    expect(Date.now() - start).toBeLessThan(maxRetryTime + 50 + 50);
+  });
+
+  it('onFailedAttempt time counts toward maxRetryTime', async () => {
+    let attempts = 0;
+    const start = Date.now();
+    const maxRetryTime = 50;
+
+    await expect(asyncRetry(
+      async () => {
+        attempts++;
+        throw new Error('fail');
+      },
+      {
+        maxRetryTime,
+        minTimeout: 0,
+        async onFailedAttempt() {
+          await wait(50);
+        }
+      }
+    )).rejects.toBeTruthy();
+
+    expect(attempts).toEqual(1);
+    expect(Date.now() - start).toBeLessThan(maxRetryTime + 50);
+  });
+
+  it('signal abort during delay cancels promptly', async () => {
+    const controller = new AbortController();
+    const start = Date.now();
+
+    // Abort shortly after the first failure schedules its delay
+    // eslint-disable-next-line sukka/prefer-timer-id -- test code
+    setTimeout(() => controller.abort(fixtureError), 10);
+
+    await expect(asyncRetry(async () => {
+      throw new Error('retry');
+    }, {
+      signal: controller.signal,
+      retries: 5,
+      minTimeout: 500,
+      factor: 2
+    })).rejects.toBe(fixtureError);
+
+    expect(Date.now() - start).toBeLessThan(1000);
+  });
+
+  it('aborts immediately if signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(asyncRetry(
+      async () => {
+        throw new Error('test');
+      },
+      { signal: controller.signal }
+    )).rejects.toBeTruthy();
+  });
+
+  it('aborts immediately if signal is already aborted with reason', async () => {
+    let called = 0;
+    const controller = new AbortController();
+    controller.abort(fixtureError);
+
+    await expect(asyncRetry(async () => {
+      called++;
+      throw new Error('should not run');
+    }, {
+      signal: controller.signal
+    })).rejects.toBe(fixtureError);
+
+    expect(called).toEqual(0);
+  });
+
+  it('throws on negative retry count', async () => {
+    await expect(
+      asyncRetry(
+        async () => {},
+        { retries: -1 }
+      )
+    ).rejects.toThrow(new TypeError('Expected `retries` to be ≥ 0.'));
+  });
+
+  it('throws on NaN retries', async () => {
+    await expect(
+      asyncRetry(
+        async () => {},
+        { retries: Number.NaN }
+      )
+    ).rejects.toThrow(new TypeError('Expected `retries` to be a valid number or Infinity, got NaN.'));
+  });
+
+  it('handles zero retries', async () => {
+    let attempts = 0;
+
+    await expect(asyncRetry(
+      async () => {
+        attempts++;
+        throw new Error('test');
+      },
+      { retries: 0 }
+    )).rejects.toBeTruthy();
+
+    expect(attempts).toEqual(1); // Should only try once with zero retries
+  });
+
+  it('onFailedAttempt still called when retries is zero', async () => {
+    let onFailedAttemptCount = 0;
+
+    await expect(asyncRetry(async () => {
+      throw new Error('fail');
+    }, {
+      retries: 0,
+      onFailedAttempt() {
+        onFailedAttemptCount++;
+      }
+    })).rejects.toBeTruthy();
+
+    expect(onFailedAttemptCount).toEqual(1);
+  });
+
+  it('invalid numeric options throw', async () => {
+    await expect(asyncRetry(async () => {}, { factor: -1 })).rejects.toBeTruthy();
+    await expect(asyncRetry(async () => {}, { minTimeout: -1 })).rejects.toBeTruthy();
+    await expect(asyncRetry(async () => {}, { maxTimeout: -1 })).rejects.toBeTruthy();
+    await expect(asyncRetry(async () => {}, { maxRetryTime: -1 })).rejects.toBeTruthy();
+  });
+
+  it('factor <= 0 is treated as 1 (stable delays)', async () => {
+    const start = Date.now();
+    let calls = 0;
+
+    await expect(asyncRetry(async () => {
+      calls++;
+      throw new Error('retry');
+    }, {
+      retries: 1,
+      minTimeout: 50,
+      factor: 0,
+      // Make delays deterministic
+      randomize: false
+    })).rejects.toBeTruthy();
+
+    // Expect ~1 delay of at least minTimeout
+    expect(Date.now() - start).toBeGreaterThanOrEqual(40);
+    expect(calls).toEqual(2);
+  });
+
+  it('handles zero maxRetryTime', async () => {
+    let attempts = 0;
+
+    await expect(asyncRetry(
+      async () => {
+        attempts++;
+        throw new Error('test');
+      },
+      { maxRetryTime: 0 }
+    )).rejects.toBeTruthy();
+
+    expect(attempts).toEqual(1); // Should only try once with zero maxRetryTime
+  });
+
+  it('handles invalid factor values', async () => {
+    const delays: number[] = [];
+    const minTimeout = 20;
+
+    await expect(asyncRetry(
+      async () => {
+        const expectedDelay = minTimeout; // Should default to minTimeout
+        delays.push(expectedDelay);
+        throw new Error('test');
+      },
+      {
+        retries: 2,
+        factor: 0, // Invalid factor
+        minTimeout,
+        randomize: false
+      }
+    )).rejects.toBeTruthy();
+
+    expect(delays[0]).toEqual(minTimeout);
+    expect(delays[1]).toEqual(minTimeout);
+  });
+
+  it('handles synchronous input function', async () => {
+    let attempts = 0;
+
+    await expect(asyncRetry(
+      () => { // Non-async function
+        attempts++;
+        throw new Error('test');
+      },
+      { retries: 2, minTimeout: 0 }
+    )).rejects.toBeTruthy();
+
+    expect(attempts).toEqual(3); // Initial + 2 retries
+  });
+
+  it('aborts retries if input function returns null', async () => {
+    let attempts = 0;
+
+    const result = await asyncRetry(
+      () => {
+        attempts++;
+        return null;
+      },
+      { retries: 2 }
+    );
+
+    expect(attempts).toEqual(1); // Should stop after first success
+    expect(result).toEqual(null);
+  });
+
+  it('respect non-Error rejection values', async () => {
+    await expect(asyncRetry(
+      // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors -- unit test
+      () => Promise.reject('string rejection'),
+      { retries: 1, minTimeout: 0 }
+    )).rejects.toEqual('string rejection');
+  });
+
+  it('unref option prevents timeout from keeping process alive', async () => {
+    const unrefSpy = spy();
+
+    const timeouts: Array<ReturnType<typeof setTimeout>> = [];
+
+    const realSetTimeout = globalThis.setTimeout;
+
+    // Stub globalThis.setTimeout to return a mock Timeout-like object with the spied unref
+    const setTimeoutStub = stub(globalThis, 'setTimeout').callsFake((fn, ms) => {
+      // Call the real setTimeout to simulate actual behavior (or fake it if you don't want real delays)
+      const realTimeout = realSetTimeout(fn, ms);
+
+      timeouts.push(realTimeout);
+
+      // Return a mock object that includes the spied unref method
+      // (In Node.js, setTimeout returns a Timeout object; we're mimicking it)
+      return {
+        ...realTimeout, // Spread the real timeout properties if needed
+        unref: unrefSpy // Replace unref with our spy
+      };
+    });
+
+    try {
+      await expect(asyncRetry(
+        async () => {
+          throw new Error('test');
+        },
+        {
+          ...sharedOpt,
+          unref: true
+        }
+      )).rejects.toBeTruthy();
+
+      expect(unrefSpy.called).toBe(true);
+    } finally {
+      setTimeoutStub.restore();
+      timeouts.forEach(clearTimeout);
+    }
+  });
+
+  it('unref option handles missing unref gracefully', async () => {
+    const timeouts: Array<ReturnType<typeof setTimeout>> = [];
+
+    const realSetTimeout = globalThis.setTimeout;
+
+    // @ts-expect-error -- fake browser timer
+    const setTimeoutStub = stub(globalThis, 'setTimeout').callsFake((fn, ms) => {
+      // Call the real setTimeout to simulate actual behavior (or fake it if you don't want real delays)
+
+      timeouts.push(realSetTimeout(fn, ms));
+
+      // Return a mock object that includes the spied unref method
+      // (In Node.js, setTimeout returns a Timeout object; we're mimicking it)
+      return 114514;
+    });
+
+    const fixtureError = new Error('fixture');
+
+    try {
+      await expect(asyncRetry(async () => {
+        throw fixtureError;
+      }, { retries: 1, minTimeout: 10, unref: true })).rejects.toBe(fixtureError);
+    } finally {
+      setTimeoutStub.restore();
+      timeouts.forEach(clearTimeout);
+    }
+  });
+
+  //   it('preserves user stack trace through async retries', async () => {
+  //     const script = `
+  // import asyncRetry from './index.js';
+
+  // async function foo1() {
+  //     return await foo2();
+  // }
+
+  // async function foo2() {
+  //     return await asyncRetry(
+  //         async () => {
+  //             throw new Error('foo2 failed');
+  //         },
+  //         {
+  //             retries: 1,
+  //         }
+  //     );
+  // }
+
+  // async function main() {
+  //     try {
+  //         await foo1();
+  //     } catch (error) {
+  //         console.error('STACKTRACE_START');
+  //         console.error(error.stack);
+  //         console.error('STACKTRACE_END');
+  //     }
+  // }
+
+  // main();
+  // `.trim();
+
+  //     const temporaryFile = path.join(process.cwd(), 'p-retry-stack-test.js');
+  //     await fs.writeFile(temporaryFile, script);
+
+  //     try {
+  //       const { stderr, stdout } = await execa('node', [temporaryFile], { reject: false });
+  //       const output = stderr + stdout;
+  //       const stack = output.split('STACKTRACE_START')[1]?.split('STACKTRACE_END')[0]?.trim();
+
+  //       expect(stack).toBeTruthy();
+
+  //       expect(stack).toMatch(/Error: foo2 failed/);
+
+  //       // Print the stack for debugging if needed
+  //       if (!/foo2/.test(stack) || !/foo1/.test(stack) || !/main/.test(stack)) {
+  //         console.log('\n==== Full stack trace for debugging ====\n' + stack + '\n==== End stack trace ====\n');
+  //       }
+
+  //       expect(stack).toMatch(/foo2/);
+  //       expect(stack).toMatch(/foo1/);
+  //       expect(stack).toMatch(/main/);
+
+  //       // Check order
+  //       const lines = stack.split('\n');
+  //       const foo2Index = lines.findIndex(line => /foo2/.test(line));
+  //       const foo1Index = lines.findIndex(line => /foo1/.test(line));
+  //       const mainIndex = lines.findIndex(line => /main/.test(line));
+
+  //       expect(foo2Index).not.toEqual(-1);
+  //       expect(foo1Index).toBeGreaterThan(foo2Index);
+  //       expect(mainIndex).toBeGreaterThan(foo1Index);
+  //     } finally {
+  //       await fs.unlink(temporaryFile);
+  //     }
+  //   });
+
+  it('makeRetriable wraps and retries the function', async () => {
+    let callCount = 0;
+    const fn = async (a: number, b: number) => {
+      callCount++;
+      if (callCount < 3) {
+        throw new Error('fail');
+      }
+
+      return a + b;
+    };
+
+    const retried = makeRetriable(fn, { retries: 5, minTimeout: 0 });
+    const result = await retried(2, 3);
+    expect(result).toEqual(5);
+    expect(callCount).toEqual(3);
+  });
+
+  it('makeRetriable passes arguments and options', async () => {
+    let lastArguments: unknown[] = [];
+    const fn = (...args: unknown[]) => {
+      lastArguments = args;
+      throw new Error('fail');
+    };
+
+    const retried = makeRetriable(fn, { retries: 1, minTimeout: 0 });
+    await expect(() => retried('foo', 42)).rejects.toBeTruthy();
+    expect(lastArguments).toEqual(['foo', 42]);
+  });
+
+  it('makeRetriable preserves `this` context', async () => {
+    const object = {
+      value: 2,
+      calls: 0,
+      async add(n: number) {
+        this.calls++;
+        if (this.calls < 2) {
+          throw new Error('fail');
+        }
+
+        return this.value + n;
+      }
+    };
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- `this` test
+    object.add = makeRetriable(object.add, { retries: 5, minTimeout: 0 });
+    const result = await object.add(3);
+    expect(result).toEqual(5);
+    expect(object.calls).toEqual(2);
+  });
+
+  it('throws error from shouldRetry', async () => {
+    const thrown = new Error('shouldRetry failure');
+
+    await expect(asyncRetry(async () => {
+      throw new Error('operation failed');
+    }, {
+      shouldRetry() {
+        throw thrown;
+      }
+    })).rejects.toThrow(thrown);
+  });
+
+  it('retriesLeft is Infinity when retries is Infinity', async () => {
+    let observed;
+
+    await expect(asyncRetry(async () => {
+      throw new Error('fail');
+    }, {
+      retries: Number.POSITIVE_INFINITY,
+      onFailedAttempt({ retriesLeft }) {
+        observed = retriesLeft;
+        throw new Error('stop');
+      },
+      minTimeout: 0
+    })).rejects.toBeTruthy();
+
+    expect(observed).toEqual(Number.POSITIVE_INFINITY);
+  });
+});

--- a/src/async-retry/index.ts
+++ b/src/async-retry/index.ts
@@ -1,0 +1,300 @@
+import { extractErrorMessage, isErrorLikeObject } from '../extract-error-message';
+import { isNetworkError } from '../is-network-error';
+import { noop, trueFn } from '../noop';
+
+export interface AsyncRetryContext {
+  readonly error: unknown,
+  readonly attemptNumber: number,
+  readonly retriesLeft: number
+}
+
+export interface AsyncRetryOptions {
+  /**
+    Callback invoked on each retry. Receives a context object containing the error and retry state information.
+
+    The `onFailedAttempt` function can return a promise. For example, to add extra delay, especially useful reading `Retry-After` header.
+
+    If the `onFailedAttempt` function throws, all retries will be aborted and the original promise will reject with the thrown error.
+    */
+  onFailedAttempt?: (context: AsyncRetryContext) => void | Promise<void>,
+
+  /**
+   * @deprecated Use `onFailedAttempt` instead. This is added only to be compatible with `async-retry`
+   */
+  onRetry?: (error: unknown, attemptNumber: number) => void | Promise<void>,
+
+  /**
+    Decide if a retry should occur based on the context. Returning true triggers a retry, false aborts with the error.
+
+    It is only called if `retries` and `maxRetryTime` have not been exhausted.
+    It is not called for `TypeError` (except network errors) and `AbortError`.
+
+    In the example above, the operation will be retried unless the error is an instance of `CustomError`.
+    */
+  shouldRetry?: (context: AsyncRetryContext) => boolean | Promise<boolean>,
+
+  /**
+   * @deprecated Use `retries` w/ `Number.POSITIVE_INFINITY` instead
+   */
+  forever?: boolean,
+
+  /**
+    The maximum amount of times to retry the operation.
+    @default 10
+    */
+  retries?: number,
+
+  /**
+    The exponential factor to use.
+    @default 2
+    */
+  factor?: number,
+
+  /**
+    The number of milliseconds before starting the first retry.
+    @default 1000
+    */
+  minTimeout?: number,
+
+  /**
+    The maximum number of milliseconds between two retries.
+    @default Infinity
+    */
+  maxTimeout?: number,
+
+  /**
+    Randomizes the timeouts by multiplying with a factor between 1 and 2.
+    @default true
+    */
+  randomize?: boolean,
+
+  /**
+    The maximum time (in milliseconds) that the retried operation is allowed to run.
+    @default Infinity
+    */
+  maxRetryTime?: number,
+
+  /**
+    You can abort retrying using [`AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController).
+    */
+  signal?: AbortSignal,
+
+  /**
+    Prevents retry timeouts from keeping the process alive.
+    Only affects platforms with a `.unref()` method on timeouts, such as Node.js.
+    @default false
+    */
+  unref?: boolean
+}
+
+interface InternalAsyncRetryOptionsWithDefaults extends
+  Pick<Required<AsyncRetryOptions>, 'retries' | 'factor' | 'minTimeout' | 'maxTimeout' | 'randomize' | 'onFailedAttempt' | 'onRetry' | 'shouldRetry'>,
+  Omit<AsyncRetryOptions, 'retries' | 'factor' | 'minTimeout' | 'maxTimeout' | 'randomize' | 'onFailedAttempt' | 'onRetry' | 'shouldRetry'> {
+}
+
+function validateNumberOption(name: string, value: number, { min = 0, allowInfinity = false } = {}) {
+  if (Number.isNaN(value)) {
+    throw new TypeError(`Expected \`${name}\` to be a valid number${allowInfinity ? ' or Infinity' : ''}, got NaN.`);
+  }
+
+  if (!allowInfinity && !Number.isFinite(value)) {
+    throw new TypeError(`Expected \`${name}\` to be a finite number.`);
+  }
+
+  if (value < min) {
+    throw new TypeError(`Expected \`${name}\` to be \u2265 ${min}.`);
+  }
+}
+
+export class AsyncRetryAbortError extends Error {
+  name = 'AsyncRetryAbortError';
+  cause: unknown;
+
+  constructor(message: string | Error | unknown) {
+    let errorMessage = '';
+    if (typeof message === 'string') {
+      errorMessage = message;
+    } else {
+      errorMessage = extractErrorMessage(message, false) ?? 'Aborted';
+    }
+
+    super(errorMessage);
+
+    if (typeof message === 'string') {
+      const cause = new Error(message);
+      cause.stack = this.stack;
+      this.cause = cause;
+    } else if (message instanceof Error) {
+      this.cause = message;
+      this.message = message.message;
+    } else {
+      this.cause = message;
+    }
+  }
+}
+
+async function onAttemptFailure(attemptError: unknown, attemptNumber: number, options: InternalAsyncRetryOptionsWithDefaults, startTime: number, maxRetryTime: number) {
+  if (attemptError instanceof AsyncRetryAbortError) {
+    throw attemptError.cause;
+  }
+
+  if (attemptError instanceof TypeError && !isNetworkError(attemptError)) {
+    throw attemptError;
+  }
+
+  if (isErrorLikeObject(attemptError) && attemptError.name === 'AbortError') {
+    throw attemptError as Error;
+  }
+
+  // Minus 1 from attemptNumber because the first attempt does not count as a retry
+  const retriesLeft = options.retries - (attemptNumber - 1);
+
+  const context: AsyncRetryContext = {
+    error: attemptError,
+    attemptNumber,
+    retriesLeft
+  };
+
+  await options.onFailedAttempt(context);
+  if (attemptNumber > 1) { // onRetry should not be called on the first initial failure
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- implementation
+    await options.onRetry(attemptError, attemptNumber - 1); // deprecated
+  }
+
+  const currentTime = Date.now();
+  if (
+    currentTime - startTime >= maxRetryTime
+    || attemptNumber >= options.retries + 1
+    || !(await options.shouldRetry(context))
+  ) {
+    throw attemptError; // Do not retry, throw the original error
+  }
+
+  // Calculate delay before next attempt
+  const random = options.randomize ? (Math.random() + 1) : 1;
+  let delayTime = Math.round(random * options.minTimeout * (options.factor ** (attemptNumber - 1)));
+  delayTime = Math.min(delayTime, options.maxTimeout);
+
+  // Ensure that delay does not exceed maxRetryTime
+  const timeLeft = maxRetryTime - (currentTime - startTime);
+  if (timeLeft <= 0) {
+    throw attemptError; // Max retry time exceeded
+  }
+
+  const finalDelay = Math.min(delayTime, timeLeft);
+
+  // Introduce delay
+  if (finalDelay > 0) {
+    await new Promise<void>((resolve, reject) => {
+      const timeoutToken = setTimeout(() => {
+        options.signal?.removeEventListener('abort', onAbort);
+        resolve();
+      }, finalDelay);
+
+      function onAbort() {
+        clearTimeout(timeoutToken);
+        options.signal?.removeEventListener('abort', onAbort);
+        // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors -- internal abort
+        reject(options.signal?.reason);
+      };
+
+      if (options.unref && typeof timeoutToken === 'object' && 'unref' in timeoutToken && typeof timeoutToken.unref === 'function') {
+        timeoutToken.unref();
+      }
+
+      options.signal?.addEventListener('abort', onAbort, { once: true });
+    });
+  }
+
+  options.signal?.throwIfAborted();
+}
+
+function bail(err: unknown) {
+  throw new AsyncRetryAbortError(err || 'Aborted');
+}
+
+export async function asyncRetry<T>(
+  callback: (
+    bail: (reason?: unknown) => void,
+    attemptNumber: number
+  ) => PromiseLike<T> | T,
+  retryOptions: AsyncRetryOptions = {}
+) {
+  const options = { ...retryOptions };
+  options.retries ??= 10;
+  // eslint-disable-next-line @typescript-eslint/no-deprecated -- implementation
+  options.forever ??= false;
+  options.factor ??= 2;
+  options.minTimeout ??= 1000;
+  options.maxTimeout ??= Number.POSITIVE_INFINITY;
+  options.randomize ??= true;
+  options.onFailedAttempt ??= noop;
+  // eslint-disable-next-line @typescript-eslint/no-deprecated -- implementation
+  options.onRetry ??= noop;
+  options.shouldRetry ??= trueFn;
+
+  // eslint-disable-next-line @typescript-eslint/no-deprecated -- implementation
+  if (options.forever) {
+    options.retries = Number.POSITIVE_INFINITY;
+  }
+
+  // Validate numeric options and normalize edge cases
+  validateNumberOption('retries', options.retries, { min: 0, allowInfinity: true });
+  validateNumberOption('factor', options.factor, { min: 0, allowInfinity: false });
+  validateNumberOption('minTimeout', options.minTimeout, { min: 0, allowInfinity: false });
+  validateNumberOption('maxTimeout', options.maxTimeout, { min: 0, allowInfinity: true });
+  const resolvedMaxRetryTime = options.maxRetryTime ?? Number.POSITIVE_INFINITY;
+  validateNumberOption('maxRetryTime', resolvedMaxRetryTime, { min: 0, allowInfinity: true });
+
+  options.minTimeout = Math.max(options.minTimeout, 1); // Ensure minTimeout is at least 1ms
+
+  // Treat non-positive factor as 1 to avoid zero backoff or negative behavior
+  if (options.factor <= 0) {
+    options.factor = 1;
+  }
+
+  options.signal?.throwIfAborted();
+
+  let attemptNumber = 0;
+  const startTime = Date.now();
+
+  // Use validated local value
+  const maxRetryTime = resolvedMaxRetryTime;
+
+  while (attemptNumber < options.retries + 1) {
+    attemptNumber++;
+
+    try {
+      options.signal?.throwIfAborted();
+
+      // eslint-disable-next-line no-await-in-loop -- retry in sequence
+      const result = await callback(bail, attemptNumber);
+
+      options.signal?.throwIfAborted();
+
+      return result;
+    } catch (error) {
+      let e = error;
+
+      // This is to be backward compatible with async-retry, which has a undocumented behavior of error.bail = true
+      if (typeof error === 'object' && error && 'bail' in error && error.bail) {
+        e = new AsyncRetryAbortError(error);
+      }
+
+      // eslint-disable-next-line no-await-in-loop -- retry in sequence
+      await onAttemptFailure(e, attemptNumber, options as InternalAsyncRetryOptionsWithDefaults, startTime, maxRetryTime);
+    }
+  }
+
+  // Should not reach here, but in case it does, throw an error
+  throw new Error('Retry attempts exhausted without throwing an error.');
+}
+
+export function makeRetriable<Args extends unknown[], Result>(
+  fn: (...args: Args) => PromiseLike<Result> | Result,
+  options?: AsyncRetryOptions
+) {
+  return function (this: unknown, ...args: Args): Promise<Result> {
+    return asyncRetry(() => fn.apply(this, args), options);
+  };
+}

--- a/src/async-retry/index.ts
+++ b/src/async-retry/index.ts
@@ -210,7 +210,7 @@ async function onAttemptFailure(attemptError: unknown, attemptNumber: number, op
 }
 
 function bail(err: unknown) {
-  throw new AsyncRetryAbortError(err || 'Aborted');
+  throw new AsyncRetryAbortError(err ?? 'Aborted');
 }
 
 export async function asyncRetry<T>(

--- a/src/is-network-error/index.ts
+++ b/src/is-network-error/index.ts
@@ -14,7 +14,7 @@ const nodeErrorCodes = new Set([
   'UND_ERR_HEADERS_TIMEOUT'
 ]);
 
-export function isNetworkError(error: unknown): error is object {
+export function isNetworkError(error: unknown): boolean {
   if (typeof error !== 'object' || error == null) {
     return false;
   }


### PR DESCRIPTION
The initial version of `async-retry`. It is compatible with both `p-retry` and `async-retry` and is designed to replace them both.