### PR TITLE
feat(abort-wait-until): bring up

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,12 @@
   ],
   "exports": {
     "./package.json": "./package.json",
+    "./abort-error": {
+      "types": "./dist/abort-error/index.d.ts",
+      "import": "./dist/abort-error/index.mjs",
+      "require": "./dist/abort-error/index.js",
+      "default": "./dist/abort-error/index.js"
+    },
     "./add-array-elements-to-set": {
       "types": "./dist/add-array-elements-to-set/index.d.ts",
       "import": "./dist/add-array-elements-to-set/index.mjs",
@@ -279,6 +285,12 @@
       "import": "./dist/wait/index.mjs",
       "require": "./dist/wait/index.js",
       "default": "./dist/wait/index.js"
+    },
+    "./wait-until": {
+      "types": "./dist/wait-until/index.d.ts",
+      "import": "./dist/wait-until/index.mjs",
+      "require": "./dist/wait-until/index.js",
+      "default": "./dist/wait-until/index.js"
     }
   },
   "sideEffects": false,

--- a/src/abort-error/index.ts
+++ b/src/abort-error/index.ts
@@ -1,0 +1,31 @@
+import { isErrorLikeObject } from '../extract-error-message';
+import type { ErrorLikeObject } from '../extract-error-message';
+
+export interface AbortErrorLike extends Omit<ErrorLikeObject, 'name'> {
+  name: 'AbortError',
+  code?: 'ABORT_ERR'
+}
+
+// https://github.com/nodejs/node/blob/0c1fb986a01c492c681bdb145ca5cba3df2dff3d/lib/internal/errors.js#L976-L988
+export class AbortError extends Error implements AbortErrorLike {
+  public readonly name = 'AbortError';
+  public readonly code = 'ABORT_ERR';
+
+  constructor(message = 'The operation was aborted', options?: ErrorOptions) {
+    super(message, options);
+  }
+}
+
+export function isAbortErrorLike(error: unknown): error is AbortErrorLike {
+  if (!isErrorLikeObject(error)) {
+    return false;
+  }
+  if (error.name === 'AbortError') {
+    return true;
+  }
+  // eslint-disable-next-line sukka/prefer-single-boolean-return -- readability
+  if ('code' in error && typeof error.code === 'string' && error.code === 'ABORT_ERR') {
+    return true;
+  }
+  return false;
+}

--- a/src/async-retry/index.ts
+++ b/src/async-retry/index.ts
@@ -1,4 +1,5 @@
-import { extractErrorMessage, isErrorLikeObject } from '../extract-error-message';
+import { isAbortErrorLike } from '../abort-error';
+import { extractErrorMessage } from '../extract-error-message';
 import { isNetworkError } from '../is-network-error';
 import { noop, trueFn } from '../noop';
 
@@ -142,7 +143,7 @@ async function onAttemptFailure(attemptError: unknown, attemptNumber: number, op
     throw attemptError;
   }
 
-  if (isErrorLikeObject(attemptError) && attemptError.name === 'AbortError') {
+  if (isAbortErrorLike(attemptError)) {
     throw attemptError as Error;
   }
 

--- a/src/wait-until/index.test.ts
+++ b/src/wait-until/index.test.ts
@@ -1,0 +1,132 @@
+import { wait as sleep } from '../wait';
+import { describe, it } from 'mocha';
+import { expect } from 'expect';
+import { waitUntil } from '.';
+import sinon from 'sinon';
+
+class TestError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TestError';
+  }
+}
+
+describe('waitUntil', () => {
+  it('Calls the predicate and resolves with a truthy result', async () => {
+    expect.assertions(1);
+
+    const initialTime = Date.now();
+    const result = await waitUntil(() => Date.now() - initialTime > 50);
+
+    expect(result).toEqual(true);
+  });
+
+  it('Calls the predicate and resolves with a non-boolean truthy result', async () => {
+    expect.assertions(1);
+
+    const initialTime = Date.now();
+    const result = await waitUntil(() => (Date.now() - initialTime > 100 ? { a: 10, b: 20 } : false));
+
+    expect(result).toEqual({ a: 10, b: 20 });
+  });
+
+  it('Supports a custom retry interval', async () => {
+    expect.assertions(3);
+
+    const initialTime = Date.now();
+    const predicate = sinon.fake(() => (Date.now() - initialTime > 200 ? { a: 10, b: 20 } : false));
+    expect(predicate.called).toBe(false);
+
+    const result = await waitUntil(predicate, 150, AbortSignal.timeout(550));
+
+    expect(predicate.callCount < Math.floor(550 / 50) - 1).toBe(true);
+    expect(result).toEqual({ a: 10, b: 20 });
+  });
+
+  it.skip('Supports waiting forever', async () => {
+    expect.assertions(3);
+
+    const initialTime = Date.now();
+    const predicate = sinon.fake(() => (Date.now() - initialTime > 1000 ? { a: 10, b: 20 } : false));
+    expect(predicate.called).toBe(false);
+    const result = await waitUntil(predicate);
+
+    expect(predicate).toHaveBeenCalled();
+    expect(result).toEqual({ a: 10, b: 20 });
+  });
+
+  it('Stops executing the predicate after timing out', async () => {
+    expect.assertions(5);
+
+    const initialTime = Date.now();
+    const predicate = sinon.fake(() => Date.now() - initialTime > 100);
+    expect(predicate.called).toBe(false);
+    try {
+      await waitUntil(predicate, AbortSignal.timeout(200));
+    } catch {
+      expect(predicate).toHaveBeenCalled();
+      const callNumber = predicate.callCount;
+      await sleep(300);
+      expect(predicate.callCount).toBe(callNumber);
+    }
+  });
+
+  it('Rejects with a timeout error when timed out', async () => {
+    try {
+      const initialTime = Date.now();
+      await waitUntil(() => Date.now() - initialTime > 200, AbortSignal.timeout(100));
+      throw new Error('Expected waitUntil to throw');
+    } catch {
+    }
+  });
+
+  it('Rejects on timeout only once', async () => {
+    expect.assertions(2);
+
+    try {
+      const initialTime = Date.now();
+      await waitUntil(() => Date.now() - initialTime > 100, AbortSignal.timeout(200));
+      throw new Error('Expected waitUntil to throw');
+    } catch {
+    }
+  });
+
+  it('Rejects on timeout once when the predicate throws an error', async () => {
+    try {
+      const initialTime = Date.now();
+      await waitUntil(
+        () => {
+          if (Date.now() - initialTime >= 100) {
+            throw new TestError('Nooo!');
+          }
+        },
+        AbortSignal.timeout(200)
+      );
+      throw new Error('Expected waitUntil to throw');
+    } catch (e) {
+      expect(e).toBeInstanceOf(TestError);
+    }
+  });
+
+  it('Rejects when the predicate throws an error', async () => {
+    expect.assertions(2);
+
+    try {
+      await waitUntil(() => {
+        throw new TestError('Crap!');
+      });
+    } catch (e) {
+      expect(e).toBeInstanceOf(Error);
+      expect(e).toBeInstanceOf(TestError);
+    }
+  });
+
+  // https://github.com/devlato/async-wait-until/issues/32
+  it('Issue #32 - does not leave open handlers when predicate returns false', async () => {
+    expect.assertions(1);
+
+    const end = Date.now() + 1000;
+    const result = await waitUntil(() => Date.now() < end);
+    expect(result).toBe(true);
+  });
+});

--- a/src/wait-until/index.ts
+++ b/src/wait-until/index.ts
@@ -1,0 +1,81 @@
+type FalsyValue = null | undefined | false | '' | 0 | void;
+
+type TruthyValue =
+  | Record<string, unknown>
+  | unknown[]
+  | symbol
+
+  | ((..._args: unknown[]) => unknown)
+  | Exclude<number, 0>
+  | Exclude<string, ''>
+  | true;
+
+export type CleanupFn = () => void;
+export type OnCleanup = (cleanUpFn: CleanupFn) => void;
+export type Scheduler = (callback: () => Promise<void>, onCleanup: OnCleanup) => void | CleanupFn;
+export type Predicate<T extends TruthyValue | FalsyValue> = () => T | Promise<T>;
+
+export function waitUntil<T extends TruthyValue | FalsyValue>(
+  predicate: Predicate<T>,
+  scheduler: Scheduler,
+  abortSignal?: AbortSignal | null,
+): Promise<T>;
+export function waitUntil<T extends TruthyValue | FalsyValue>(
+  predicate: Predicate<T>,
+  checkInterval?: number,
+  abortSignal?: AbortSignal | null
+): Promise<T>;
+export function waitUntil<T extends TruthyValue | FalsyValue>(
+  predicate: Predicate<T>,
+  abortSignal: AbortSignal,
+): Promise<T>;
+export function waitUntil<T extends TruthyValue | FalsyValue>(
+  predicate: Predicate<T>,
+  scheduler: AbortSignal | Scheduler | number = 50,
+  abortSignal: AbortSignal | never | null = null
+): Promise<T> {
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+
+  if (typeof scheduler === 'object' && 'aborted' in scheduler) {
+    abortSignal = scheduler;
+    scheduler = 50;
+  }
+  if (typeof scheduler === 'number') {
+    const timeout = scheduler;
+    scheduler = (callback, onCleanup) => {
+      const intervalHandle = setTimeout(callback, timeout);
+      onCleanup(() => clearTimeout(intervalHandle));
+    };
+  }
+
+  abortSignal ??= AbortSignal.timeout(5000);
+
+  const cleanUp = new Set<() => void>();
+  const onCleanup: OnCleanup = (fn) => cleanUp.add(fn);
+
+  const promise: Promise<T> = new Promise<T>((resolve, reject) => {
+    const check = async () => {
+      try {
+        abortSignal.throwIfAborted();
+
+        const value = await predicate();
+        if (value) {
+          resolve(value);
+          return;
+        }
+
+        scheduler(check, onCleanup);
+      } catch (err) {
+        reject(err as Error);
+      }
+    };
+    void check();
+  });
+
+  return promise.finally(() => {
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle);
+    }
+    cleanUp.forEach((fn) => fn());
+  });
+}


### PR DESCRIPTION
The PR does 3 things:

- Add `AbortError` and related utils
- Use `isAbortErrorLikeObject` in `async-retry`
- Add `waitUntil`