### PR TITLE
fix(wait-until): handle clean up fn as a return value

### DIFF
--- a/src/wait-until/index.ts
+++ b/src/wait-until/index.ts
@@ -64,7 +64,10 @@ export function waitUntil<T extends TruthyValue | FalsyValue>(
           return;
         }
 
-        scheduler(check, onCleanup);
+        const cleanup = scheduler(check, onCleanup);
+        if (typeof cleanup === 'function') {
+          cleanUp.add(cleanup);
+        }
       } catch (err) {
         reject(err as Error);
       }


### PR DESCRIPTION
#4 I forgot to handle the clean-up function as a return value. The PR fixes it.