### PR TITLE
perf(fnv*): significantly increase speed

### DIFF
--- a/src/fnv1a/index.bench.ts
+++ b/src/fnv1a/index.bench.ts
@@ -1,0 +1,36 @@
+import { fnv1a, fnv1ahex } from '.';
+
+export function sinderSlowFnv1a(s: string) {
+  let h = 0x81_1C_9D_C5;
+
+  for (let i = 0, l = s.length; i < l; i++) {
+    h ^= s.charCodeAt(i);
+    h += (h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24);
+  }
+
+  return (h >>> 0);
+}
+
+(async () => {
+  const { bench, group, run } = await import('mitata');
+
+  group('fnv1a', () => {
+    bench('sinderSlowFnv1a', () => {
+      sinderSlowFnv1a('the quick brown fox jumps over the lazy dog').toString(16);
+    });
+    bench('foxts/fnv1a', () => {
+      fnv1a('the quick brown fox jumps over the lazy dog');
+    });
+  });
+
+  group('hex', () => {
+    bench('toString(16)', () => {
+      fnv1a('the quick brown fox jumps over the lazy dog').toString(16);
+    });
+    bench('fnv1ahex', () => {
+      fnv1ahex('the quick brown fox jumps over the lazy dog');
+    });
+  });
+
+  run();
+})();

--- a/src/fnv1a/index.test.ts
+++ b/src/fnv1a/index.test.ts
@@ -1,13 +1,32 @@
 import { describe, it } from 'mocha';
 import { expect } from 'expect';
-import { fnv1a } from '.';
+import { fnv1ahex, fnv1a } from '.';
+
+export function sinderSlowFnv1a(s: string) {
+  let h = 0x81_1C_9D_C5;
+
+  for (let i = 0, l = s.length; i < l; i++) {
+    h ^= s.charCodeAt(i);
+    h += (h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24);
+  }
+
+  return (h >>> 0);
+}
 
 describe('fnv1a', () => {
   const hash1 = 'hello world';
   const hash2 = 'the quick brown fox jumps over the lazy dog';
 
-  it('should work', () => {
+  it('fnv1a', () => {
     expect(fnv1a(hash1)).toBe(3_582_672_807);
     expect(fnv1a(hash2)).toBe(4_016_652_272);
+
+    expect(sinderSlowFnv1a(hash1)).toBe(sinderSlowFnv1a(hash1));
+    expect(sinderSlowFnv1a(hash2)).toBe(sinderSlowFnv1a(hash2));
+  });
+
+  it('fnv1a hex', () => {
+    expect(fnv1ahex(hash1)).toBe(fnv1a(hash1).toString(16));
+    expect(fnv1ahex(hash2)).toBe(fnv1a(hash2).toString(16));
   });
 });

--- a/src/fnv1a/index.ts
+++ b/src/fnv1a/index.ts
@@ -1,10 +1,72 @@
-export function fnv1a(s: string) {
-  let h = 0x81_1C_9D_C5;
+export function fnv1a(str: string) {
+  const l = str.length - 3;
+  let i = 0, t0 = 0, v0 = 0x9DC5, t1 = 0, v1 = 0x811C;
 
-  for (let i = 0, l = s.length; i < l; i++) {
-    h ^= s.charCodeAt(i);
-    h += (h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24);
+  while (i < l) {
+    v0 ^= str.charCodeAt(i++);
+    t0 = v0 * 403; t1 = v1 * 403;
+    t1 += v0 << 8;
+    v1 = (t1 + (t0 >>> 16)) & 65535; v0 = t0 & 65535;
+    v0 ^= str.charCodeAt(i++);
+    t0 = v0 * 403; t1 = v1 * 403;
+    t1 += v0 << 8;
+    v1 = (t1 + (t0 >>> 16)) & 65535; v0 = t0 & 65535;
+    v0 ^= str.charCodeAt(i++);
+    t0 = v0 * 403; t1 = v1 * 403;
+    t1 += v0 << 8;
+    v1 = (t1 + (t0 >>> 16)) & 65535; v0 = t0 & 65535;
+    v0 ^= str.charCodeAt(i++);
+    t0 = v0 * 403; t1 = v1 * 403;
+    t1 += v0 << 8;
+    v1 = (t1 + (t0 >>> 16)) & 65535; v0 = t0 & 65535;
   }
 
-  return (h >>> 0);
+  while (i < l + 3) {
+    v0 ^= str.charCodeAt(i++);
+    t0 = v0 * 403; t1 = v1 * 403;
+    t1 += v0 << 8;
+    v1 = (t1 + (t0 >>> 16)) & 65535; v0 = t0 & 65535;
+  }
+
+  return ((v1 << 16) >>> 0) + v0;
+}
+
+const hl: string[] = new Array(256);
+for (let i = 0; i < 256; i++) {
+  hl[i] = ((i >> 4) & 15).toString(16) + (i & 15).toString(16);
+}
+
+export const __internal_hl_do_not_use__ = hl;
+
+export function fnv1ahex(str: string) {
+  const l = str.length - 3;
+  let i = 0, t0 = 0, v0 = 0x9DC5, t1 = 0, v1 = 0x811C;
+
+  while (i < l) {
+    v0 ^= str.charCodeAt(i++);
+    t0 = v0 * 403; t1 = v1 * 403;
+    t1 += v0 << 8;
+    v1 = (t1 + (t0 >>> 16)) & 65535; v0 = t0 & 65535;
+    v0 ^= str.charCodeAt(i++);
+    t0 = v0 * 403; t1 = v1 * 403;
+    t1 += v0 << 8;
+    v1 = (t1 + (t0 >>> 16)) & 65535; v0 = t0 & 65535;
+    v0 ^= str.charCodeAt(i++);
+    t0 = v0 * 403; t1 = v1 * 403;
+    t1 += v0 << 8;
+    v1 = (t1 + (t0 >>> 16)) & 65535; v0 = t0 & 65535;
+    v0 ^= str.charCodeAt(i++);
+    t0 = v0 * 403; t1 = v1 * 403;
+    t1 += v0 << 8;
+    v1 = (t1 + (t0 >>> 16)) & 65535; v0 = t0 & 65535;
+  }
+
+  while (i < l + 3) {
+    v0 ^= str.charCodeAt(i++);
+    t0 = v0 * 403; t1 = v1 * 403;
+    t1 += v0 << 8;
+    v1 = (t1 + (t0 >>> 16)) & 65535; v0 = t0 & 65535;
+  }
+
+  return hl[(v1 >>> 8) & 255] + hl[v1 & 255] + hl[(v0 >>> 8) & 255] + hl[v0 & 255];
 }

--- a/src/fnv1a52/index.bench.ts
+++ b/src/fnv1a52/index.bench.ts
@@ -1,0 +1,16 @@
+import { fnv1a52, fnv1a52hex } from '.';
+
+(async () => {
+  const { bench, group, run } = await import('mitata');
+
+  group('fnv1a52 - hex', () => {
+    bench('fnv1a52 + toString(16)', () => {
+      fnv1a52('the quick brown fox jumps over the lazy dog').toString(16);
+    });
+    bench('fnv1a52hex', () => {
+      fnv1a52hex('the quick brown fox jumps over the lazy dog');
+    });
+  });
+
+  run();
+})();

--- a/src/fnv1a52/index.test.ts
+++ b/src/fnv1a52/index.test.ts
@@ -1,13 +1,17 @@
 import { describe, it } from 'mocha';
 import { expect } from 'expect';
-import { fnv1a52 } from '.';
+import { fnv1a52, fnv1a52hex } from '.';
 
 describe('fnv1a52', () => {
   const hash1 = 'hello world';
   const hash2 = 'the quick brown fox jumps over the lazy dog';
 
-  it('should work', () => {
+  it('fnv1a52', () => {
     expect(fnv1a52(hash1)).toBe(2_926_792_616_498_590);
     expect(fnv1a52(hash2)).toBe(1_353_091_865_156_848);
+  });
+
+  it('fnv1a52hex', () => {
+    expect(fnv1a52hex(hash1)).toBe(fnv1a52(hash1).toString(16));
   });
 });

--- a/src/fnv1a52/index.ts
+++ b/src/fnv1a52/index.ts
@@ -1,11 +1,18 @@
+import { __internal_hl_do_not_use__ as hl } from '../fnv1a';
+
 /**
  * FNV-1a Hash implementation
+ *
+ * @author Sukka (sukkaw) <https://skk.moe>
  * @author Travis Webb (tjwebb) <me@traviswebb.com>
  *
- * Ported from https://github.com/tjwebb/fnv-plus/blob/master/index.js
+ * @description
  *
+ * Ported from https://github.com/tjwebb/fnv-plus/blob/master/index.js
  * Simplified, optimized and add modified for 52 bit, which provides a larger hash space
  * and still making use of Javascript's 53-bit integer space.
+ *
+ * DO NOT USE toString(16) here! Use `fnv1a52hex` instead, way faster
  */
 export function fnv1a52(str: string) {
   const len = str.length;
@@ -41,4 +48,37 @@ export function fnv1a52(str: string) {
     + v1 * 65536
     + (v0 ^ (v3 >> 4))
   );
+}
+
+const hl16 = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'];
+
+export function fnv1a52hex(str: string) {
+  const len = str.length;
+  let i = 0,
+    t0 = 0,
+    v0 = 0x2325,
+    t1 = 0,
+    v1 = 0x8422,
+    t2 = 0,
+    v2 = 0x9CE4,
+    t3 = 0,
+    v3 = 0xCBF2;
+
+  while (i < len) {
+    v0 ^= str.charCodeAt(i++);
+    t0 = v0 * 435;
+    t1 = v1 * 435;
+    t2 = v2 * 435;
+    t3 = v3 * 435;
+    t2 += v0 << 8;
+    t3 += v1 << 8;
+    t1 += t0 >>> 16;
+    v0 = t0 & 65535;
+    t2 += t1 >>> 16;
+    v1 = t1 & 65535;
+    v3 = (t3 + (t2 >>> 16)) & 65535;
+    v2 = t2 & 65535;
+  }
+
+  return hl16[v3 & 15] + hl[v2 >> 8] + hl[v2 & 255] + hl[v1 >> 8] + hl[v1 & 255] + hl[(v0 >> 8) ^ (v3 >> 12)] + hl[(v0 ^ (v3 >> 4)) & 255];
 }


### PR DESCRIPTION
- Increase `fnv1a` performance by 500%
- Add new `fnv1ahex` method which is 10x faster than `fnv1a().toString(16)`
- Add new `fnv1a52hex` method which is 6x faster than `fnv1a52hex().toString(16)`
- Add benchmarks to validate the above results
