### PR TITLE
feat(simple-cors): bring up

### DIFF
--- a/package.json
+++ b/package.json
@@ -268,6 +268,12 @@
       "require": "./dist/shuffle-array/index.js",
       "default": "./dist/shuffle-array/index.js"
     },
+    "./simple-cors": {
+      "types": "./dist/simple-cors/index.d.ts",
+      "import": "./dist/simple-cors/index.mjs",
+      "require": "./dist/simple-cors/index.js",
+      "default": "./dist/simple-cors/index.js"
+    },
     "./simple-string-hash": {
       "types": "./dist/simple-string-hash/index.d.ts",
       "import": "./dist/simple-string-hash/index.mjs",

--- a/src/simple-cors/index.test.ts
+++ b/src/simple-cors/index.test.ts
@@ -1,0 +1,251 @@
+import { describe, it } from 'mocha';
+import { expect } from 'expect';
+import { createSimpleCors } from '.';
+
+describe('merge-headers', () => {
+  const cors1 = createSimpleCors();
+  const cors2 = createSimpleCors({
+    origin: 'http://example.com',
+    allowHeaders: ['X-Custom-Header', 'Upgrade-Insecure-Requests'],
+    allowMethods: ['POST', 'GET', 'OPTIONS'],
+    exposeHeaders: ['Content-Length', 'X-Kuma-Revision'],
+    maxAge: 600,
+    credentials: true
+  });
+  const cors3 = createSimpleCors({
+    origin: ['http://example.com', 'http://example.org', 'http://example.dev']
+  });
+  const cors4 = createSimpleCors({
+    origin: (origin) => (origin.endsWith('.example.com') ? origin : 'http://example.com')
+  });
+
+  const cors5 = createSimpleCors();
+  const cors6 = createSimpleCors({
+    origin: 'http://example.com'
+  });
+
+  const cors7 = createSimpleCors({
+    origin: (origin) => (origin === 'http://example.com' ? origin : '*'),
+    allowMethods: (origin) => (origin === 'http://example.com'
+      ? ['GET', 'HEAD', 'POST', 'PATCH', 'DELETE']
+      : ['GET', 'HEAD'])
+  });
+
+  const cors8 = createSimpleCors({
+    origin: (origin) => new Promise<string>((resolve) => { resolve(origin.endsWith('.example.com') ? origin : 'http://example.com'); })
+  });
+
+  const cors9 = createSimpleCors({
+    origin: (origin) => new Promise<string>((resolve) => { resolve(origin === 'http://example.com' ? origin : '*'); }),
+    allowMethods: (origin) => new Promise<string[]>((resolve) => {
+      resolve(
+        origin === 'http://example.com'
+          ? ['GET', 'HEAD', 'POST', 'PATCH', 'DELETE']
+          : ['GET', 'HEAD']
+      );
+    })
+  });
+
+  it('GET default', async () => {
+    const res = await cors1(new Request('http://localhost/api/abc'), Response.json({}));
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    expect(res.headers.get('Vary')).toBeNull();
+  });
+
+  it('Preflight default', async () => {
+    const req = new Request('https://localhost/api/abc', { method: 'OPTIONS' });
+    req.headers.append('Access-Control-Request-Headers', 'X-PINGOTHER, Content-Type');
+    const res = await cors1(new Request(req), new Response(null, { status: 204 }));
+
+    expect(res.status).toBe(204);
+    expect(res.headers.get('Access-Control-Allow-Methods')?.split(',')[0]).toBe('GET');
+    expect(res.headers.get('Access-Control-Allow-Headers')?.split(',')).toEqual([
+      'X-PINGOTHER',
+      'Content-Type'
+    ]);
+  });
+
+  it('Preflight with options', async () => {
+    const req = new Request('https://localhost/api2/abc', {
+      method: 'OPTIONS',
+      headers: { origin: 'http://example.com' }
+    });
+
+    const res = await cors2(new Request(req), new Response(null, { status: 204 }));
+
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://example.com');
+    expect(res.headers.get('Vary')?.split(/\s*,\s*/)).toEqual(expect.arrayContaining(['Origin']));
+    expect(res.headers.get('Access-Control-Allow-Headers')?.split(/\s*,\s*/)).toEqual([
+      'X-Custom-Header',
+      'Upgrade-Insecure-Requests'
+    ]);
+    expect(res.headers.get('Access-Control-Allow-Methods')?.split(/\s*,\s*/)).toEqual([
+      'POST',
+      'GET',
+      'OPTIONS'
+    ]);
+    expect(res.headers.get('Access-Control-Expose-Headers')?.split(/\s*,\s*/)).toEqual([
+      'Content-Length',
+      'X-Kuma-Revision'
+    ]);
+    expect(res.headers.get('Access-Control-Max-Age')).toBe('600');
+    expect(res.headers.get('Access-Control-Allow-Credentials')).toBe('true');
+  });
+
+  it('Disallow an unmatched origin', async () => {
+    const req = new Request('https://localhost/api2/abc', {
+      method: 'OPTIONS',
+      headers: { origin: 'http://example.net' }
+    });
+    const res = await cors2(new Request(req), new Response(null, { status: 204 }));
+    expect(res.headers.has('Access-Control-Allow-Origin')).toBeFalsy();
+  });
+
+  it('Allow multiple origins', async () => {
+    let req = new Request('http://localhost/api3/abc', {
+      headers: {
+        Origin: 'http://example.org'
+      }
+    });
+    let res = await cors3(new Request(req), Response.json({}));
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://example.org');
+
+    req = new Request('http://localhost/api3/abc');
+    res = await cors3(new Request(req), Response.json({}));
+    expect(
+      res.headers.has('Access-Control-Allow-Origin')
+      // 'An unmatched origin should be disallowed'
+    ).toBeFalsy();
+
+    req = new Request('http://localhost/api3/abc', {
+      headers: {
+        Referer: 'http://example.net/'
+      }
+    });
+    res = await cors3(new Request(req), Response.json({}));
+    expect(
+      res.headers.has('Access-Control-Allow-Origin')
+      // 'An unmatched origin should be disallowed'
+    ).toBeFalsy();
+  });
+
+  it('Allow different Vary header value', async () => {
+    const res = await cors3(new Request('http://localhost/api3/abc', {
+      headers: {
+        Vary: 'accept-encoding',
+        Origin: 'http://example.com'
+      }
+    }), Response.json({}));
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://example.com');
+    expect(res.headers.get('Vary')).toBe('accept-encoding');
+  });
+
+  it('Allow origins by function', async () => {
+    let req = new Request('http://localhost/api4/abc', {
+      headers: {
+        Origin: 'http://subdomain.example.com'
+      }
+    });
+    let res = await cors4(new Request(req), Response.json({}));
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://subdomain.example.com');
+
+    req = new Request('http://localhost/api4/abc');
+    res = await cors4(new Request(req), Response.json({}));
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://example.com');
+
+    req = new Request('http://localhost/api4/abc', {
+      headers: {
+        Referer: 'http://evil-example.com/'
+      }
+    });
+    res = await cors4(new Request(req), Response.json({}));
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://example.com');
+  });
+
+  it('Allow origins by promise returning function', async () => {
+    let req = new Request('http://localhost/api8/abc', {
+      headers: {
+        Origin: 'http://subdomain.example.com'
+      }
+    });
+    let res = await cors8(new Request(req), Response.json({}));
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://subdomain.example.com');
+
+    req = new Request('http://localhost/api8/abc');
+    res = await cors8(new Request(req), Response.json({}));
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://example.com');
+
+    req = new Request('http://localhost/api8/abc', {
+      headers: {
+        Referer: 'http://evil-example.com/'
+      }
+    });
+    res = await cors8(new Request(req), Response.json({}));
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://example.com');
+  });
+
+  it('With raw Response object', async () => {
+    const res = await cors5(new Request('http://localhost/api5/abc'), Response.json({}));
+
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    expect(res.headers.get('Vary')).toBeNull();
+  });
+
+  it('Should not return duplicate header values', async () => {
+    const res = await cors6(new Request('http://localhost/api6/abc', {
+      headers: {
+        origin: 'http://example.com'
+      }
+    }), Response.json({}));
+
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://example.com');
+  });
+
+  it('Allow methods by function', async () => {
+    const req = new Request('http://localhost/api7/abc', {
+      headers: {
+        Origin: 'http://example.com'
+      },
+      method: 'OPTIONS'
+    });
+    const res = await cors7(new Request(req), Response.json({}));
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://example.com');
+    expect(res.headers.get('Access-Control-Allow-Methods')).toBe('GET,HEAD,POST,PATCH,DELETE');
+
+    const req2 = new Request('http://localhost/api7/abc', {
+      headers: {
+        Origin: 'http://example.org'
+      },
+      method: 'OPTIONS'
+    });
+    const res2 = await cors7(new Request(req2), Response.json({}));
+    expect(res2.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    expect(res2.headers.get('Access-Control-Allow-Methods')).toBe('GET,HEAD');
+  });
+
+  it('Allow methods by promise returning function', async () => {
+    const req = new Request('http://localhost/api9/abc', {
+      headers: {
+        Origin: 'http://example.com'
+      },
+      method: 'OPTIONS'
+    });
+    const res = await cors9(new Request(req), Response.json({}));
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://example.com');
+    expect(res.headers.get('Access-Control-Allow-Methods')).toBe('GET,HEAD,POST,PATCH,DELETE');
+
+    const req2 = new Request('http://localhost/api9/abc', {
+      headers: {
+        Origin: 'http://example.org'
+      },
+      method: 'OPTIONS'
+    });
+    const res2 = await cors9(new Request(req2), Response.json({}));
+    expect(res2.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    expect(res2.headers.get('Access-Control-Allow-Methods')).toBe('GET,HEAD');
+  });
+});

--- a/src/simple-cors/index.ts
+++ b/src/simple-cors/index.ts
@@ -91,7 +91,7 @@ export function createSimpleCors(options?: SimpleCorsOptions) {
       response.headers.set('Access-Control-Allow-Credentials', 'true');
     }
     if (opts.exposeHeaders?.length) {
-      response.headers.set('Access-Control-Expose-Headers', opts.exposeHeaders.join(', '));
+      response.headers.set('Access-Control-Expose-Headers', fastStringArrayJoin(opts.exposeHeaders, ','));
     }
 
     let allowMethods = findAllowMethods(request.headers.get('origin') || '');
@@ -99,7 +99,7 @@ export function createSimpleCors(options?: SimpleCorsOptions) {
       allowMethods = await allowMethods;
     }
     if (allowMethods.length) {
-      response.headers.set('Access-Control-Allow-Methods', allowMethods.join(','));
+      response.headers.set('Access-Control-Allow-Methods', fastStringArrayJoin(allowMethods, ','));
     }
 
     if (request.method === 'OPTIONS') {

--- a/src/simple-cors/index.ts
+++ b/src/simple-cors/index.ts
@@ -1,0 +1,131 @@
+import { fastStringArrayJoin } from '../fast-string-array-join';
+
+export interface SimpleCorsOptions {
+  origin:
+    | string
+    | string[]
+    | ((origin: string) => Promise<string | undefined | null> | string | undefined | null),
+  allowMethods?: string[] | ((origin: string) => Promise<string[]> | string[]),
+  allowHeaders?: string[],
+  maxAge?: number,
+  credentials?: boolean,
+  exposeHeaders?: string[]
+};
+
+/**
+ * A very simple CORS implementation for using in simple serverless workers
+ *
+ * Example usage:
+ *
+ * ```ts
+ * const simpleCors = createSimpleCors({});
+ *
+ * export function fetch(req: Request) {
+ *   if (req.method === 'OPTIONS') {
+ *     return simpleCors(req, new Response(null, { status: 204 });
+ *   }
+ *   const resp = Response.json({ message: 'Hello, world!' });
+ *   return simpleCors(req, resp);
+ * }
+ * ```
+ */
+export function createSimpleCors(options?: SimpleCorsOptions) {
+  const defaults: SimpleCorsOptions = {
+    origin: '*',
+    allowMethods: ['GET', 'HEAD', 'PUT', 'POST', 'DELETE', 'PATCH'],
+    allowHeaders: [],
+    exposeHeaders: []
+  };
+  const opts = {
+    ...defaults,
+    ...options
+  };
+
+  let findAllowOrigin: (origin: string) => Promise<string | undefined | null> | string | undefined | null;
+  const optsOrigin = opts.origin;
+  if (typeof optsOrigin === 'string') {
+    if (optsOrigin === '*') {
+      findAllowOrigin = () => '*';
+    } else {
+      findAllowOrigin = (origin: string) => (optsOrigin === origin ? origin : null);
+    }
+  } else if (typeof optsOrigin === 'function') {
+    findAllowOrigin = optsOrigin;
+  } else {
+    const allowedOrigins = new Set(optsOrigin);
+    findAllowOrigin = (origin: string) => (allowedOrigins.has(origin) ? origin : null);
+  }
+
+  let findAllowMethods: (origin: string) => Promise<string[]> | string[];
+  const optsAllowMethods = opts.allowMethods;
+  if (typeof optsAllowMethods === 'function') {
+    findAllowMethods = optsAllowMethods;
+  } else if (Array.isArray(optsAllowMethods)) {
+    findAllowMethods = () => optsAllowMethods;
+  } else {
+    findAllowMethods = () => [];
+  }
+
+  const shouldVaryIncludeOrigin = optsOrigin !== '*';
+
+  return async function simpleCors(request: Request, response: Response): Promise<Response> {
+    let allowOrigin = findAllowOrigin(request.headers.get('Origin') || '');
+    if (allowOrigin && typeof allowOrigin === 'object' && 'then' in allowOrigin) {
+      allowOrigin = await allowOrigin;
+    }
+    if (allowOrigin) {
+      response.headers.set('Access-Control-Allow-Origin', allowOrigin);
+    }
+    // Suppose the server sends a response with an Access-Control-Allow-Origin value with an explicit origin (rather than the "*" wildcard).
+    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
+    if (shouldVaryIncludeOrigin) {
+      const existingVary = request.headers.get('Vary');
+
+      if (existingVary) {
+        response.headers.set('Vary', existingVary);
+      } else {
+        response.headers.set('Vary', 'Origin');
+      }
+    }
+    if (opts.credentials) {
+      response.headers.set('Access-Control-Allow-Credentials', 'true');
+    }
+    if (opts.exposeHeaders?.length) {
+      response.headers.set('Access-Control-Expose-Headers', opts.exposeHeaders.join(', '));
+    }
+
+    let allowMethods = findAllowMethods(request.headers.get('origin') || '');
+    if ('then' in allowMethods) {
+      allowMethods = await allowMethods;
+    }
+    if (allowMethods.length) {
+      response.headers.set('Access-Control-Allow-Methods', allowMethods.join(','));
+    }
+
+    if (request.method === 'OPTIONS') {
+      if (opts.maxAge != null) {
+        response.headers.set('Access-Control-Max-Age', opts.maxAge.toString());
+      }
+
+      let headers = opts.allowHeaders;
+      if (!headers?.length) {
+        const requestHeaders = request.headers.get('Access-Control-Request-Headers');
+        if (requestHeaders) {
+          headers = requestHeaders.split(/\s*,\s*/);
+        }
+      }
+      if (headers?.length) {
+        response.headers.set('Access-Control-Allow-Headers', fastStringArrayJoin(headers, ','));
+        response.headers.append('Vary', 'Access-Control-Request-Headers');
+      }
+
+      // return new Response(null, {
+      //   headers: c.res.headers,
+      //   status: 204,
+      //   statusText: 'No Content'
+      // });
+    }
+
+    return response;
+  };
+}


### PR DESCRIPTION
This is a very simple helper function when writing small/simple serverless workers/edge functions where you need CORS but you don't have access to `hono/cors` or similar things.

Example usage:

```ts
const cors = createSimpleCors();

export function fetch(req: Request) {
  if (req.method === 'OPTIONS') {
    return simpleCors(req, new Response(null, { status: 204 });
  }
  // Your logic here
  const resp = Response.json({ message: 'Hello, world!' });
  return simpleCors(req, resp);
}
```