### PR TITLE
chore: add package metadata links

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "repository": {
     "url": "https://github.com/SukkaW/foxts"
   },
+  "homepage": "https://github.com/SukkaW/foxts#readme",
+  "bugs": {
+    "url": "https://github.com/SukkaW/foxts/issues"
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
## Summary

Adds standard npm metadata links to the published `foxts` package manifest:

- `homepage` points to the repository README
- `bugs.url` points to the repository issue tracker

## Verification

```bash
python3 -m json.tool package.json >/tmp/foxts-package-json.out
node - <<'NODE'
const fs = require('fs');
const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
if (pkg.homepage !== 'https://github.com/SukkaW/foxts#readme') throw new Error('homepage mismatch');
if (!pkg.bugs || pkg.bugs.url !== 'https://github.com/SukkaW/foxts/issues') throw new Error('bugs mismatch');
console.log(JSON.stringify({name: pkg.name, homepage: pkg.homepage, bugs: pkg.bugs, repository: pkg.repository, license: pkg.license}, null, 2));
NODE
git diff --check
```
