### PR TITLE
fix: add missing npm metadata fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -381,5 +381,9 @@
     "typescript": "^6.0.3",
     "word-list": "3.0.0"
   },
-  "packageManager": "pnpm@11.5.2"
+  "packageManager": "pnpm@11.5.2",
+  "bugs": {
+    "url": "https://github.com/SukkaW/foxts/issues"
+  },
+  "homepage": "https://github.com/SukkaW/foxts#readme"
 }


### PR DESCRIPTION
Adds missing npm metadata fields to improve package discoverability.